### PR TITLE
Enable to change `status_emoji`

### DIFF
--- a/denops/slack-status/app.ts
+++ b/denops/slack-status/app.ts
@@ -44,10 +44,6 @@ main(async ({ vim }) => {
     ":speech_balloon:",
   ) as string;
 
-  if (statusEmoji === "") {
-    statusEmoji = ":speech_balloon:";
-  }
-
   const messageContent = await vim.g.get(
     "slack_status_message",
     '["I\'m coding ", &filetype]',

--- a/denops/slack-status/app.ts
+++ b/denops/slack-status/app.ts
@@ -1,6 +1,7 @@
 import { main } from "https://deno.land/x/denops_std@v0.8/mod.ts";
 
 let token: string | undefined = undefined;
+let statusEmoji: string;
 
 const changeStatus = async (...args: Array<unknown>) => {
   const status = (args as Array<string>).join("");
@@ -14,6 +15,7 @@ const changeStatus = async (...args: Array<unknown>) => {
     profile: {
       status_text: status,
       status_expiration: Math.floor(Date.now() / 1000) + 1200,
+      status_emoji: statusEmoji,
     },
   };
 
@@ -35,6 +37,15 @@ main(async ({ vim }) => {
   if (token == null || token === "") {
     console.log("[SlackStatus] Token is not set");
     return;
+  }
+
+  statusEmoji = await vim.g.get(
+    "slack_status_emoji",
+    ":speech_balloon:",
+  ) as string;
+
+  if (statusEmoji === "") {
+    statusEmoji = ":speech_balloon:";
   }
 
   const messageContent = await vim.g.get(


### PR DESCRIPTION
This PR make enable to change the `status_emoji`.
The default emoji is `: speech_balloon:`. (Bacause when the slack api gets a post request without `status_emoji`, the api sets it as the default value)